### PR TITLE
Hang CPU if kernel falls through

### DIFF
--- a/code/rube-os/src/boot.S
+++ b/code/rube-os/src/boot.S
@@ -5,3 +5,8 @@
 _start:
 
     call main
+
+    ; hang the CPU if the kernel falls through
+    .hang:
+        hlt
+        jmp .hang

--- a/code/rube_os_boot_rom/src/boot.S
+++ b/code/rube_os_boot_rom/src/boot.S
@@ -5,3 +5,8 @@
 
 _boot:  
     call main
+
+    ; hang the CPU if the kernel falls through
+    .hang:
+        hlt
+        jmp .hang


### PR DESCRIPTION
This is beneficial from a security standpoint. In the future it might be good to try and save data and restart the OS, however this is currently a security risk if the C/C++ falls through for the time being.